### PR TITLE
[docs] Batch5.5 adding back example for div

### DIFF
--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -995,11 +995,11 @@ Returns the result of integer division of `x` by `y`.
 
 </details>
 
-<!-- :::info
+:::info
 
   The `DIV` function is not implemented in Druid versions 30.0.0 or earlier. Consider using [`SAFE_DIVIDE`](./sql-functions.md/#safe_divide) instead. 
 
-::: -->
+:::
 
 [Learn more](sql-scalar.md#numeric-functions)
 

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -978,7 +978,7 @@ Returns the result of integer division of `x` by `y`.
 * **Syntax:** `DIV(x, y)`
 * **Function type:** Scalar, numeric
 
-<!--
+
 <details><summary>Example</summary>
 
   The following calculates integer divisions of `78` by `10`.
@@ -994,13 +994,12 @@ Returns the result of integer division of `x` by `y`.
   | `7` |
 
 </details>
--->
 
-:::info
+<!-- :::info
 
   The `DIV` function is not implemented in Druid versions 30.0.0 or earlier. Consider using [`SAFE_DIVIDE`](./sql-functions.md/#safe_divide) instead. 
 
-:::
+::: -->
 
 [Learn more](sql-scalar.md#numeric-functions)
 


### PR DESCRIPTION
## Description

Adds example back to `DIV` function under the expectation that the function will work in versions 31.0.0 and above. Currently does not work, should not be released in any earlier versions of Druid. 

This PR has:

- [X] been self-reviewed.
- [X] Link-linter passed
- [X] Spellchecker passed