### PR TITLE
[docs] Batch14 changes to hll functions

### DIFF
--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -1070,8 +1070,7 @@ The following example creates an HLL sketch on the `Tail_number` column from the
 SELECT
   "OriginState" AS "origin_state",
   "DestState" AS "destination_state",
-  DS_HLL("Tail_Number") AS "hll_tail_number",
-  COUNT(DISTINCT "Tail_Number") AS "grouped_rows"
+  DS_HLL("Tail_Number") AS "hll_tail_number"
 FROM "flight-carriers"
 GROUP BY 1,2
 LIMIT 1
@@ -1079,9 +1078,9 @@ LIMIT 1
 
 Returns the following:
 
-| `origin_state` | `destination_state` | `hll_tail_number` | `grouped_rows`|
-| -- | -- | -- | -- | 
-| `AK` | `AK` | `"AwEHDAcIAAFBAAAAfY..."` | `64` | 
+| `origin_state` | `destination_state` | `hll_tail_number` | 
+| -- | -- | -- | 
+| `AK` | `AK` | `"AwEHDAcIAAFBAAAAfY..."` |
 
 </details>
 

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -1071,7 +1071,7 @@ SELECT
   "OriginState" AS "origin_state",
   "DestState" AS "destination_state",
   DS_HLL("Tail_Number") AS "hll_tail_number",
-  COUNT(DISTINCT "Reporting_Airline") AS "group_rows"
+  COUNT(DISTINCT "Tail_Number") AS "grouped_rows"
 FROM "flight-carriers"
 GROUP BY 1,2
 LIMIT 1
@@ -1081,7 +1081,7 @@ Returns the following:
 
 | `origin_state` | `destination_state` | `hll_tail_number` | `grouped_rows`|
 | -- | -- | -- | -- | 
-| `AK` | `AK` | `"AwEHDAcIAAFBAAAA..."` | `1` | 
+| `AK` | `AK` | `"AwEHDAcIAAFBAAAAfY..."` | `64` | 
 
 </details>
 

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -116,14 +116,14 @@ Counts distinct values of a string, numeric, or `hyperUnique` column using Druid
 
 ## APPROX_COUNT_DISTINCT_DS_HLL
 
-Approximates distinct values of a HLL sketch column or a regular column. See [DataSketches HLL Sketch module](../development/extensions-core/datasketches-hll.md) for a description of optional parameters.
+Returns the approximate number of distinct values in a HLL sketch column or a regular column. See [DataSketches HLL Sketch module](../development/extensions-core/datasketches-hll.md) for a description of optional parameters.
 
 * **Syntax:** `APPROX_COUNT_DISTINCT_DS_HLL(expr, [lgK, tgtHllType])`
 * **Function type:** Aggregation
 
 <details><summary>Example</summary>
 
-The following example returns the approximate number of distinct tail numbers in the `flight_carriers` datasource.
+The following example returns the approximate number of distinct tail numbers in the `flight-carriers` datasource.
 
 ```sql
 SELECT APPROX_COUNT_DISTINCT_DS_HLL("Tail_Number") AS "estimate"
@@ -1064,7 +1064,7 @@ Creates a HLL sketch on a column containing HLL sketches or a regular column. Se
 
 <details><summary>Example</summary>
 
-The following example creates a HLL sketch on the `Tail_number` column from the `flight-carriers` dataset, grouping by `OriginState` and `DestState`.
+The following example creates a HLL sketch on the `Tail_number` column of the `flight-carriers` datasource grouping by `OriginState` and `DestState`.
 
 ```sql
 SELECT
@@ -1269,7 +1269,7 @@ Returns a number for each output row of a groupBy query, indicating whether the 
 
 ## HLL_SKETCH_ESTIMATE
 
-Returns a distinct count estimate from a HLL sketch. To round the distinct count estimate, set `round` to true. Otherwise, `round` defaults to false.
+Returns the distinct count estimate from a HLL sketch. To round the distinct count estimate, set `round` to true. `round` defaults to false.
 
 * **Syntax:** `HLL_SKETCH_ESTIMATE(expr, [round])`
 * **Function type:** Scalar, sketch
@@ -1277,7 +1277,7 @@ Returns a distinct count estimate from a HLL sketch. To round the distinct count
 
 <details><summary>Example</summary>
 
-The following example estimates the number of unique tail numbers in the `flight-carriers` datasource.
+The following example estimates the distinct number of unique tail numbers in the `flight-carriers` datasource.
 
 ```sql
 SELECT
@@ -1297,7 +1297,7 @@ Returns the following:
 
 ## HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS
 
-Returns the distinct count estimate and error bounds from a HLL sketch. To specify the number of standard deviations of the bounds use `numStdDev`.
+Returns the distinct count estimate and error bounds from a HLL sketch. To specify the number of standard bound deviations, use `numStdDev`.
 
 * **Syntax:** `HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS(expr, [numStdDev])`
 * **Function type:** Scalar, sketch
@@ -1332,7 +1332,7 @@ Returns a human-readable string representation of a HLL sketch for debugging.
 
 <details><summary>Example</summary>
 
-The following example returns the HLL sketch on column `Tail_Number` from the `flight-carriers` as a human-readable string.
+The following example returns the HLL sketch on column `Tail_Number` from the `flight-carriers` datasource as a human-readable string.
 
 ```sql
 SELECT
@@ -1385,7 +1385,7 @@ Returns a union of HLL sketches. See [DataSketches HLL Sketch module](../develop
 
 <details><summary>Example</summary>
 
-The following example estimates the union of the HLL sketch of tail numbers that took off from `CA` and the HLL sketch of tail numbers that took off from `TX`. The examples uses the `Tail_Number` and `OriginState` columns from the `flight-carriers` datasource. 
+The following example estimates the union of the HLL sketch of tail numbers that took off from `CA` and the HLL sketch of tail numbers that took off from `TX`. The example uses the `Tail_Number` and `OriginState` columns from the `flight-carriers` datasource. 
 
 ```sql
 SELECT

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -1064,7 +1064,7 @@ Creates an HLL sketch on a column containing HLL sketches or a regular column. T
 
 <details><summary>Example</summary>
 
-The following example creates an HLL sketch on the `Tail_number` column from the `flight-carriers` dataset, grouping by `originState` and `DestState`.
+The following example creates an HLL sketch on the `Tail_number` column from the `flight-carriers` dataset, grouping by `OriginState` and `DestState`.
 
 ```sql
 SELECT
@@ -1269,7 +1269,7 @@ Returns a number for each output row of a groupBy query, indicating whether the 
 
 ## HLL_SKETCH_ESTIMATE
 
-Returns the distinct count estimate from an HLL sketch. The `expr` argument must return an HLL sketch. The optional `round` boolean argument rounds the estimate if set to true, with a default of false.
+Returns a distinct count estimate from an HLL sketch. To round the distinct count estimate, set `round` to true. Otherwise, `round` defaults to false.
 
 * **Syntax:** `HLL_SKETCH_ESTIMATE(expr, [round])`
 * **Function type:** Scalar, sketch
@@ -1281,7 +1281,7 @@ The following example estimates the number of unique tail numbers in the `flight
 
 ```sql
 SELECT
-  HLL_SKETCH_ESTIMATE(DS_HLL("Tail_Number"), False) AS "estimate"
+  HLL_SKETCH_ESTIMATE(DS_HLL("Tail_Number")) AS "estimate"
 FROM "flight-carriers"
 ```
 
@@ -1379,7 +1379,7 @@ Returns the following:
 
 ## HLL_SKETCH_UNION
 
-Returns a union of HLL sketches, where each input expression must return an HLL sketch. The [HLL sketch documentation](../development//extensions-core//datasketches-hll.md) describes the optional `lgK` and `tgtHllType` arguments.
+Returns a union of HLL sketches, where each input expression is an HLL sketch. See [DataSketches HLL Sketch module](../development/extensions-core/datasketches-hll.md) for a description of optional parameters.
 
 * **Syntax:** `HLL_SKETCH_UNION([lgK, tgtHllType], expr0, expr1, ...)`
 * **Function type:** Scalar, sketch

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -116,7 +116,7 @@ Counts distinct values of a string, numeric, or `hyperUnique` column using Druid
 
 ## APPROX_COUNT_DISTINCT_DS_HLL
 
-Approximates distinct values of an HLL sketch column or a regular column. The [HLL sketch documentation](../development/extensions-core/datasketches-hll.md) describes the optional `lgK` and `tgtHllType` arguments.
+Approximates distinct values of a HLL sketch column or a regular column. See [DataSketches HLL Sketch module](../development/extensions-core/datasketches-hll.md) for a description of optional parameters.
 
 * **Syntax:** `APPROX_COUNT_DISTINCT_DS_HLL(expr, [lgK, tgtHllType])`
 * **Function type:** Aggregation
@@ -1057,14 +1057,14 @@ Returns a string representing an approximation to the histogram given the specif
 
 ## DS_HLL
 
-Creates an HLL sketch on a column containing HLL sketches or a regular column. The [HLL sketch documentation](../development/extensions-core/datasketches-hll.md) describes the optional `lgK` and `tgtHllType` arguments.
+Creates a HLL sketch on a column containing HLL sketches or a regular column. See [DataSketches HLL Sketch module](../development/extensions-core/datasketches-hll.md) for a description of optional parameters.
 
 * **Syntax:**`DS_HLL(expr, [lgK, tgtHllType])`
 * **Function type:** Aggregation
 
 <details><summary>Example</summary>
 
-The following example creates an HLL sketch on the `Tail_number` column from the `flight-carriers` dataset, grouping by `OriginState` and `DestState`.
+The following example creates a HLL sketch on the `Tail_number` column from the `flight-carriers` dataset, grouping by `OriginState` and `DestState`.
 
 ```sql
 SELECT
@@ -1269,7 +1269,7 @@ Returns a number for each output row of a groupBy query, indicating whether the 
 
 ## HLL_SKETCH_ESTIMATE
 
-Returns a distinct count estimate from an HLL sketch. To round the distinct count estimate, set `round` to true. Otherwise, `round` defaults to false.
+Returns a distinct count estimate from a HLL sketch. To round the distinct count estimate, set `round` to true. Otherwise, `round` defaults to false.
 
 * **Syntax:** `HLL_SKETCH_ESTIMATE(expr, [round])`
 * **Function type:** Scalar, sketch
@@ -1289,7 +1289,7 @@ Returns the following:
 
 | `estimate` | 
 | -- |
-| `4,685.8815405960595` |
+| `4685.8815405960595` |
 
 </details>
 
@@ -1297,7 +1297,7 @@ Returns the following:
 
 ## HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS
 
-Returns the distinct count estimate and error bounds from an HLL sketch. The `expr` argument must return an HLL sketch. The optional round `numStdDev` argument rounds the estimate if set to true, with a default of false.
+Returns the distinct count estimate and error bounds from a HLL sketch. To specify the number of standard deviations of the bounds use `numStdDev`.
 
 * **Syntax:** `HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS(expr, [numStdDev])`
 * **Function type:** Scalar, sketch
@@ -1316,7 +1316,7 @@ Returns the following:
 
 | `estimate_with_errors` |
 | -- |
-| `[4685.8815405960595, 4536.952802775876, 4839.925808688653]` |
+| `[4685.8815405960595,4611.381540678335,4762.978259800803]` |
 
 
 </details>
@@ -1325,7 +1325,7 @@ Returns the following:
 
 ## HLL_SKETCH_TO_STRING
 
-Returns a human-readable string representation of an HLL sketch for debugging. The `expr` argument must return an HLL sketch.
+Returns a human-readable string representation of a HLL sketch for debugging.
 
 * **Syntax:** `HLL_SKETCH_TO_STRING(expr)`
 * **Function type:** Scalar, sketch
@@ -1371,15 +1371,13 @@ Returns the following:
 </tr>
 </table>
 
-
 </details>
 
 [Learn more](sql-scalar.md#sketch-functions)
 
-
 ## HLL_SKETCH_UNION
 
-Returns a union of HLL sketches, where each input expression is an HLL sketch. See [DataSketches HLL Sketch module](../development/extensions-core/datasketches-hll.md) for a description of optional parameters.
+Returns a union of HLL sketches. See [DataSketches HLL Sketch module](../development/extensions-core/datasketches-hll.md) for a description of optional parameters.
 
 * **Syntax:** `HLL_SKETCH_UNION([lgK, tgtHllType], expr0, expr1, ...)`
 * **Function type:** Scalar, sketch
@@ -1387,7 +1385,7 @@ Returns a union of HLL sketches, where each input expression is an HLL sketch. S
 
 <details><summary>Example</summary>
 
-The following example estimates the number of unique tail numbers that took off from California or Texas by estimating on the union of the HLL sketch of tail numbers that took off from `CA` and the HLL sketch of tail numbers that took off from `TX` from the `flight-carriers` datasource. 
+The following example estimates the union of the HLL sketch of tail numbers that took off from `CA` and the HLL sketch of tail numbers that took off from `TX`. The examples uses the `Tail_Number` and `OriginState` columns from the `flight-carriers` datasource. 
 
 ```sql
 SELECT

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -116,11 +116,29 @@ Counts distinct values of a string, numeric, or `hyperUnique` column using Druid
 
 ## APPROX_COUNT_DISTINCT_DS_HLL
 
-`APPROX_COUNT_DISTINCT_DS_HLL(expr, [<NUMERIC>, <CHARACTER>])`
+Approximates distinct values of an HLL sketch column or a regular column. The [HLL sketch documentation](../development/extensions-core/datasketches-hll.md) describes the optional `lgK` and `tgtHllType` arguments.
 
-**Function type:** [Aggregation](sql-aggregations.md)
+* **Syntax:** `APPROX_COUNT_DISTINCT_DS_HLL(expr, [lgK, tgtHllType])`
+* **Function type:** Aggregation
 
-Counts distinct values of an HLL sketch column or a regular column.
+<details><summary>Example</summary>
+
+The following example returns the approximate number of distinct tail numbers in the `flight_carriers` datasource.
+
+```sql
+SELECT APPROX_COUNT_DISTINCT_DS_HLL("Tail_Number") AS "estimate"
+FROM "flight-carriers"
+```
+
+Returns the following:
+
+| `estimate` |
+| -- |
+| `4686` |
+
+</details>
+
+[Learn more](sql-aggregations.md)
 
 ## APPROX_COUNT_DISTINCT_DS_THETA
 
@@ -1039,11 +1057,36 @@ Returns a string representing an approximation to the histogram given the specif
 
 ## DS_HLL
 
-`DS_HLL(expr, [lgK, tgtHllType])`
+Creates an HLL sketch on a column containing HLL sketches or a regular column. The [HLL sketch documentation](../development/extensions-core/datasketches-hll.md) describes the optional `lgK` and `tgtHllType` arguments.
 
-**Function type:** [Aggregation](sql-aggregations.md)
+* **Syntax:**`DS_HLL(expr, [lgK, tgtHllType])`
+* **Function type:** Aggregation
 
-Creates an HLL sketch on a column containing HLL sketches or a regular column.
+<details><summary>Example</summary>
+
+The following example creates an HLL sketch on the `Tail_number` column from the `flight-carriers` dataset, grouping by `originState` and `DestState`.
+
+```sql
+SELECT
+  "OriginState" AS "origin_state",
+  "DestState" AS "destination_state",
+  DS_HLL("Tail_Number") AS "hll_tail_number",
+  COUNT(DISTINCT "Reporting_Airline") AS "group_rows"
+FROM "flight-carriers"
+GROUP BY 1,2
+LIMIT 1
+```
+
+Returns the following:
+
+| `origin_state` | `destination_state` | `hll_tail_number` | `grouped_rows`|
+| -- | -- | -- | -- | 
+| `AK` | `AK` | `"AwEHDAcIAAFBAAAA..."` | `1` | 
+
+</details>
+
+
+[Learn more](sql-aggregations.md)
 
 ## DS_QUANTILE_SUMMARY
 
@@ -1227,35 +1270,146 @@ Returns a number for each output row of a groupBy query, indicating whether the 
 
 ## HLL_SKETCH_ESTIMATE
 
-`HLL_SKETCH_ESTIMATE(expr, [round])`
+Returns the distinct count estimate from an HLL sketch. The `expr` argument must return an HLL sketch. The optional `round` boolean argument rounds the estimate if set to true, with a default of false.
 
-**Function type:** [Scalar, sketch](sql-scalar.md#sketch-functions)
+* **Syntax:** `HLL_SKETCH_ESTIMATE(expr, [round])`
+* **Function type:** Scalar, sketch
 
-Returns the distinct count estimate from an HLL sketch.
+
+<details><summary>Example</summary>
+
+The following example estimates the number of unique tail numbers in the `flight-carriers` datasource.
+
+```sql
+SELECT
+  HLL_SKETCH_ESTIMATE(DS_HLL("Tail_Number"), False) AS "estimate"
+FROM "flight-carriers"
+```
+
+Returns the following:
+
+| `estimate` | 
+| -- |
+| `4,685.8815405960595` |
+
+</details>
+
+[Learn more](sql-scalar.md#sketch-functions)
 
 ## HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS
 
-`HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS(expr, [numStdDev])`
+Returns the distinct count estimate and error bounds from an HLL sketch. The `expr` argument must return an HLL sketch. The optional round `numStdDev` argument rounds the estimate if set to true, with a default of false.
 
-**Function type:** [Scalar, sketch](sql-scalar.md#sketch-functions)
+* **Syntax:** `HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS(expr, [numStdDev])`
+* **Function type:** Scalar, sketch
 
-Returns the distinct count estimate and error bounds from an HLL sketch.
+<details><summary>Example</summary>
+
+The following example estimates the number of unique tail numbers in the `flight-carriers` datasource with error bounds at plus or minus one standard deviation.
+
+```sql
+SELECT
+  HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS(DS_HLL("Tail_Number"), 1) AS "estimate_with_errors"
+FROM "flight-carriers"
+```
+
+Returns the following:
+
+| `estimate_with_errors` |
+| -- |
+| `[4685.8815405960595, 4536.952802775876, 4839.925808688653]` |
+
+
+</details>
+
+[Learn more](sql-scalar.md#sketch-functions)
 
 ## HLL_SKETCH_TO_STRING
 
-`HLL_SKETCH_TO_STRING(expr)`
+Returns a human-readable string representation of an HLL sketch for debugging. The `expr` argument must return an HLL sketch.
 
-**Function type:** [Scalar, sketch](sql-scalar.md#sketch-functions)
+* **Syntax:** `HLL_SKETCH_TO_STRING(expr)`
+* **Function type:** Scalar, sketch
 
-Returns a human-readable string representation of an HLL sketch.
+<details><summary>Example</summary>
+
+The following example returns the HLL sketch on column `Tail_Number` from the `flight-carriers` as a human-readable string.
+
+```sql
+SELECT
+  HLL_SKETCH_TO_STRING( DS_HLL("Tail_Number") ) AS "summary"
+FROM "flight-carriers"
+```
+
+Returns the following:
+
+<table>
+<tr>
+<td><code>summary</code></td>
+</tr>
+<tr>
+<td>
+
+```
+### HLL SKETCH SUMMARY: 
+  Log Config K   : 12
+  Hll Target     : HLL_4
+  Current Mode   : HLL
+  Memory         : false
+  LB             : 4611.381540678335
+  Estimate       : 4685.8815405960595
+  UB             : 4762.978259800803
+  OutOfOrder Flag: true
+  CurMin         : 0
+  NumAtCurMin    : 1316
+  HipAccum       : 0.0
+  KxQ0           : 2080.7755126953125
+  KxQ1           : 0.0
+  Rebuild KxQ Flg: false
+```
+
+</td>
+</tr>
+</table>
+
+
+</details>
+
+[Learn more](sql-scalar.md#sketch-functions)
+
 
 ## HLL_SKETCH_UNION
 
-`HLL_SKETCH_UNION([lgK, tgtHllType], expr0, expr1, ...)`
+Returns a union of HLL sketches, where each input expression must return an HLL sketch. The [HLL sketch documentation](../development//extensions-core//datasketches-hll.md) describes the optional `lgK` and `tgtHllType` arguments.
 
-**Function type:** [Scalar, sketch](sql-scalar.md#sketch-functions)
+* **Syntax:** `HLL_SKETCH_UNION([lgK, tgtHllType], expr0, expr1, ...)`
+* **Function type:** Scalar, sketch
 
-Returns a union of HLL sketches.
+
+<details><summary>Example</summary>
+
+The following example estimates the number of unique tail numbers that took off from California or Texas by estimating on the union of the HLL sketch of tail numbers that took off from `CA` and the HLL sketch of tail numbers that took off from `TX` from the `flight-carriers` datasource. 
+
+```sql
+SELECT
+  HLL_SKETCH_ESTIMATE(
+    HLL_SKETCH_UNION( 
+      DS_HLL("Tail_Number") FILTER(WHERE "OriginState" = 'CA'),
+      DS_HLL("Tail_Number") FILTER(WHERE "OriginState" = 'TX')
+    )
+  ) AS "estimate_union"
+FROM "flight-carriers"
+```
+
+Returns the following:
+
+| `estimate_union` |
+| -- |
+| `4204.798431046455` |
+
+</details>
+
+[Learn more](sql-scalar.md#sketch-functions)
 
 ## HUMAN_READABLE_BINARY_BYTE_FORMAT
 
@@ -3028,5 +3182,3 @@ Calculates the sample variance of a set of values.
 **Function type:** [Aggregation](sql-aggregations.md)
 
 Alias for [`VAR_SAMP`](#var_samp).
-
-

--- a/docs/querying/sql-scalar.md
+++ b/docs/querying/sql-scalar.md
@@ -223,8 +223,8 @@ The [DataSketches extension](../development/extensions-core/datasketches-extensi
 
 |Function|Notes|
 |--------|-----|
-|`HLL_SKETCH_ESTIMATE(expr[, round])`|Returns a distinct count estimate from an HLL sketch. `expr` must be an HLL sketch. To round the estimate, set `round` to true. Otherwise, `round` defaults to false.|
-|`HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS(expr[, numStdDev])`|Returns a distinct count estimate and error bounds from an HLL sketch. `expr` must be an HLL sketch. `numStdDev` argument specifies the number of standard deviations of the bounds. `numStdDev` must be `1`, `2`, or `3`. |
+|`HLL_SKETCH_ESTIMATE(expr[, round])`|Returns a distinct count estimate from a HLL sketch. `expr` must be a HLL sketch. To round the estimate, set `round` to true. Otherwise, `round` defaults to false.|
+|`HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS(expr[, numStdDev])`|Returns a distinct count estimate and error bounds from a HLL sketch. `expr` must be a HLL sketch. `numStdDev` argument specifies the number of standard deviations of the bounds. `numStdDev` must be `1`, `2`, or `3`. |
 |`HLL_SKETCH_UNION([lgK, tgtHllType], expr0, expr1, ...)`|Returns a union of HLL sketches, where each input expression must return an HLL sketch. The `lgK` and `tgtHllType` can be optionally specified as the first parameter; if provided, both optional parameters must be specified.|
 |`HLL_SKETCH_TO_STRING(expr)`|Returns a human-readable string representation of an HLL sketch for debugging. `expr` must return an HLL sketch.|
 

--- a/docs/querying/sql-scalar.md
+++ b/docs/querying/sql-scalar.md
@@ -223,8 +223,8 @@ The [DataSketches extension](../development/extensions-core/datasketches-extensi
 
 |Function|Notes|
 |--------|-----|
-|`HLL_SKETCH_ESTIMATE(expr[, round])`|Returns the distinct count estimate from an HLL sketch. `expr` must return an HLL sketch. The optional `round` boolean argument rounds the estimate if set to `true`, with a default of `false`.|
-|`HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS(expr[, numStdDev])`|Returns the distinct count estimate and error bounds from an HLL sketch. `expr` must return an HLL sketch. An optional `numStdDev` argument specifies the number of standard deviations of the bounds. `numStdDev` must be `1`, `2`, or `3`. |
+|`HLL_SKETCH_ESTIMATE(expr[, round])`|Returns a distinct count estimate from an HLL sketch. `expr` must be an HLL sketch. To round the estimate, set `round` to true. Otherwise, `round` defaults to false.|
+|`HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS(expr[, numStdDev])`|Returns a distinct count estimate and error bounds from an HLL sketch. `expr` must be an HLL sketch. `numStdDev` argument specifies the number of standard deviations of the bounds. `numStdDev` must be `1`, `2`, or `3`. |
 |`HLL_SKETCH_UNION([lgK, tgtHllType], expr0, expr1, ...)`|Returns a union of HLL sketches, where each input expression must return an HLL sketch. The `lgK` and `tgtHllType` can be optionally specified as the first parameter; if provided, both optional parameters must be specified.|
 |`HLL_SKETCH_TO_STRING(expr)`|Returns a human-readable string representation of an HLL sketch for debugging. `expr` must return an HLL sketch.|
 

--- a/docs/querying/sql-scalar.md
+++ b/docs/querying/sql-scalar.md
@@ -223,8 +223,8 @@ The [DataSketches extension](../development/extensions-core/datasketches-extensi
 
 |Function|Notes|
 |--------|-----|
-|`HLL_SKETCH_ESTIMATE(expr[, round])`|Returns the distinct count estimate from an HLL sketch. `expr` must return an HLL sketch. The optional `round` boolean parameter will round the estimate if set to `true`, with a default of `false`.|
-|`HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS(expr[, numStdDev])`|Returns the distinct count estimate and error bounds from an HLL sketch. `expr` must return an HLL sketch. An optional `numStdDev` argument can be provided.|
+|`HLL_SKETCH_ESTIMATE(expr[, round])`|Returns the distinct count estimate from an HLL sketch. `expr` must return an HLL sketch. The optional `round` boolean argument rounds the estimate if set to `true`, with a default of `false`.|
+|`HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS(expr[, numStdDev])`|Returns the distinct count estimate and error bounds from an HLL sketch. `expr` must return an HLL sketch. An optional `numStdDev` argument specifies the number of standard deviations of the bounds. `numStdDev` must be `1`, `2`, or `3`. |
 |`HLL_SKETCH_UNION([lgK, tgtHllType], expr0, expr1, ...)`|Returns a union of HLL sketches, where each input expression must return an HLL sketch. The `lgK` and `tgtHllType` can be optionally specified as the first parameter; if provided, both optional parameters must be specified.|
 |`HLL_SKETCH_TO_STRING(expr)`|Returns a human-readable string representation of an HLL sketch for debugging. `expr` must return an HLL sketch.|
 


### PR DESCRIPTION
### Description

Updating HLL sketch functions in`sql-funcitons.md`. Functions are: `APPROX_COUNT_DISTINCT_DS_HLL`, `DS_HLL`, `HLL_SKETCH_ESTIMATE`, `HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS`, `HLL_SKETCH_TO_STRING`, `HLL_SKETCH_UNION`, and `APPROX_COUNT_DISTINCT_DS_HLL`.

This PR has:

- [X] been self-reviewed.
- [X] Link-linter passed
- [X] Spellchecker passed