### PR TITLE
[docs] Batch16 - Quantiles

### DIFF
--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -1108,7 +1108,7 @@ SELECT DS_GET_QUANTILE( DS_QUANTILES_SKETCH("Distance"), 0.5) AS "estimate_media
 FROM "flight-carriers"
 ```
 
-May return the following:
+Returns a result similar to the following:
 
 | `estimate_median` |
 | -- | 
@@ -1134,7 +1134,7 @@ SELECT DS_GET_QUANTILES( DS_QUANTILES_SKETCH("Distance"), 0.25, 0.5, 0.75) AS "e
 FROM "flight-carriers"
 ```
 
-May returns the following:
+Returns a result similar to the following:
 
 | `estimate_fractions` |
 | -- | 
@@ -1161,7 +1161,7 @@ FROM "flight-carriers"
 
 ```
 
-May return the following:
+Returns a result similar to the following:
 
 | `estimate_histogram` | 
 | -- |
@@ -1278,7 +1278,7 @@ Returns a result similar to the following:
 
 | `estimate_rank` |
 | -- |
-| `0.43791089804959216` |
+| `0.43837721544923675 ` |
 
 
 </details>
@@ -1317,7 +1317,7 @@ Returns an intersection of Tuple sketches which each contain an array of double 
 
 **Function type:** [Scalar, sketch](sql-scalar.md#tuple-sketch-functions)
 
-Computes approximate sums of the values contained within a Tuple sketch which contains an array of double values as the Summary Object. 
+Computes approximate sums of the values contained within a Tuple sketch which contains an array of double values as the Summary Object.
 
 ## DS_TUPLE_DOUBLES_NOT
 

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -137,29 +137,29 @@ Counts distinct values of a Theta sketch column or a regular column.
 Deprecated in favor of [`APPROX_QUANTILE_DS`](#approx_quantile_ds).
 :::
 
-* **Syntax:** `APPROX_QUANTILE(expr, fraction, [k])`
+* **Syntax:** `APPROX_QUANTILE(expr, probability, [k])`
 * **Function type:** Aggregation
 
 [Learn more](sql-aggregations.md)
 
 ## APPROX_QUANTILE_DS
 
-Computes approximate quantiles on a Quantiles sketch column or a regular numeric column. The parameter `k` determines the accuracy and size of the sketch. The [DataSketches Quantiles Sketch module](../development/extensions-core/datasketches-quantiles.md) provides more information on the parameter `k`.
+Computes approximate quantiles on a Quantiles sketch column or a regular numeric column. See [DataSketches Quantiles Sketch module](../development/extensions-core/datasketches-quantiles.md) for a description of parameters.
 
-* **Syntax:** `APPROX_QUANTILE_DS(expr, fraction, [k])`
+* **Syntax:** `APPROX_QUANTILE_DS(expr, probability, [k])`
 * **Function type:** Aggregation
 
 
 <details><summary>Example</summary>
 
-The following example approximates the median of the `Distance` column from the `flight-carriers` datasource using a `k` value of 128. The query may return a different approximation on each execution.
+The following example approximates the median of the `Distance` column from the `flight-carriers` datasource. The query may return a different approximation on each execution.
 
 ```sql
 SELECT APPROX_QUANTILE_DS("Distance", 0.5, 128)  AS "estimate_median"
 FROM "flight-carriers"
 ```
 
-May return the following:
+Returns a result similar to the following:
 
 | `estimate_median` |
 | -- | 
@@ -171,7 +171,7 @@ May return the following:
 
 ## APPROX_QUANTILE_FIXED_BUCKETS
 
-Computes approximate quantiles on fixed buckets histogram column or a regular numeric column. The [fixed buckets histogram](../development/extensions-core/approximate-histograms.md#fixed-buckets-histogram) documentation describes the parameters.
+Computes approximate quantiles on fixed buckets histogram column or a regular numeric column. See [Fixed buckets histogram](../development/extensions-core/approximate-histograms.md#fixed-buckets-histogram) for a description of parameters.
 
 * **Syntax:** `APPROX_QUANTILE_FIXED_BUCKETS(expr, probability, numBuckets, lowerLimit, upperLimit, [outlierHandlingMode])`
 * **Function type:** Aggregation
@@ -179,7 +179,7 @@ Computes approximate quantiles on fixed buckets histogram column or a regular nu
 
 <details><summary>Example</summary>
 
-The following example approximates the median of a histogram on the `Distance` column from the `flight-carriers` datasource. The histogram has 10 buckets, a lower limit of zero, an upper limit of 2500, and outliers are ignored. 
+The following example approximates the median of a histogram on the `Distance` column from the `flight-carriers` datasource. The histogram has 10 buckets, a lower limit of zero, an upper limit of 2500, and ignores outlier values. 
 
 ```sql
 SELECT APPROX_QUANTILE_FIXED_BUCKETS("Distance", 0.5, 10, 0, 2500, 'ignore')  AS "estimate_median"
@@ -1082,7 +1082,7 @@ SELECT DS_CDF( DS_QUANTILES_SKETCH("Distance"), 750, 1500, 2250) AS "estimate_cd
 FROM "flight-carriers"
 ```
 
-May return the following:
+Returns a result similar to the following:
 
 | `estimate_cdf` | 
 | -- |
@@ -1094,7 +1094,7 @@ May return the following:
 
 ## DS_GET_QUANTILE
 
-Returns the quantile estimate corresponding to `fraction` from a Quantiles sketch. 
+Returns the quantile estimate corresponding to the fraction from a Quantiles sketch. 
 
 * **Syntax:** `DS_GET_QUANTILE(expr, fraction)`
 * **Function type:** Scalar, sketch
@@ -1146,7 +1146,7 @@ May returns the following:
 
 ## DS_HISTOGRAM
 
-Returns a string representing an approximation to the histogram given a list of split points that define the histogram bins from a Quantiles sketch. 
+Returns an approximation to the histogram from a Quantiles sketch. The split points define the histogram bins. 
 
 * **Syntax:** `DS_HISTOGRAM(expr, splitPoint0, splitPoint1, ...)`
 * **Function type:** Scalar, sketch
@@ -1165,7 +1165,7 @@ May return the following:
 
 | `estimate_histogram` | 
 | -- |
-| `[354396.0,150199.00000000003,39848.000000000015,21694.99999999997]` |
+| `[358496.0,153974.99999999997,39909.99999999999,13757.000000000005]` |
 
 </details>
 
@@ -1187,7 +1187,7 @@ Returns a string summary of a Quantiles sketch.
 
 <details><summary>Example</summary>
 
-The following example returns a summary of a Quantiles sketch on the `Distance` column from the `flight-carriers`.
+The following example returns a summary of a Quantiles sketch on the `Distance` column from the `flight-carriers` datasource.
 
 ```sql
 SELECT DS_QUANTILE_SUMMARY( DS_QUANTILES_SKETCH("Distance") ) AS "summary"
@@ -1234,7 +1234,7 @@ Returns the following:
 
 ## DS_QUANTILES_SKETCH
 
-Creates a Quantiles sketch on a column containing Quantiles sketches or a regular column. The parameter `k` determines the accuracy and size of the sketch. The [DataSketches Quantiles Sketch module](../development/extensions-core/datasketches-quantiles.md) provides more information on the parameter `k`.
+Creates a Quantiles sketch on a Quantiles sketch column or a regular column. See [DataSketches Quantiles Sketch module](../development/extensions-core/datasketches-quantiles.md) for a description of parameters.
 
 * **Syntax:** `DS_QUANTILES_SKETCH(expr, [k])`
 * **Function type:** Aggregation
@@ -1260,21 +1260,21 @@ Returns the following:
 
 ## DS_RANK
 
-Returns an approximate rank for `value` between zero and one, in which the rank signifies the fraction of the distribution less than `value`.
+Returns an approximate rank of a given value in a distribution. The rank represents the fraction of the distribution less than the given value.
 
 * **Syntax:** `DS_RANK(expr, value)`
 * **Function type:** Scalar, sketch
 
 <details><summary>Example</summary>
 
-The following example approximates what fraction of records have a lesser value than `500` in the `Distance` column from the `flight-carries` datasource. The query may return a different approximation on each execution.
+The following example estimates the fraction of records in the `flight-carriers` datasource where the value in the `Distance` column is less than 500. The query may return a different approximation on each execution.
 
 ```sql
 SELECT DS_RANK( DS_QUANTILES_SKETCH("Distance"), 500) AS "estimate_rank"
 FROM "flight-carriers"
 ```
 
-May return the following:
+Returns a result similar to the following:
 
 | `estimate_rank` |
 | -- |

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -133,27 +133,68 @@ Counts distinct values of a Theta sketch column or a regular column.
 
 ## APPROX_QUANTILE
 
-`APPROX_QUANTILE(expr, <NUMERIC>, [<NUMERIC>])`
+:::info
+Deprecated in favor of [`APPROX_QUANTILE_DS`](#approx_quantile_ds).
+:::
 
-**Function type:** [Aggregation](sql-aggregations.md)
+* **Syntax:** `APPROX_QUANTILE(expr, fraction, [k])`
+* **Function type:** Aggregation
 
-Deprecated in favor of `APPROX_QUANTILE_DS`.
+[Learn more](sql-aggregations.md)
 
 ## APPROX_QUANTILE_DS
 
-`APPROX_QUANTILE_DS(expr, <NUMERIC>, [<NUMERIC>])`
+Computes approximate quantiles on a Quantiles sketch column or a regular numeric column. The `fraction` argument must be a value between zero and one. The optional argument `k` determines the accuracy and size of the sketch. The [DataSketches Quantiles Sketch module](../development/extensions-core/datasketches-quantiles.md) provides more information on what values of `k` are accepted..
 
-**Function type:** [Aggregation](sql-aggregations.md)
+* **Syntax:** `APPROX_QUANTILE_DS(expr, fraction, [k])`
+* **Function type:** Aggregation
 
-Computes approximate quantiles on a Quantiles sketch column or a regular numeric column.
+
+<details><summary>Example</summary>
+
+The following example approximates the median of the `Distance` column from the `flight-carriers` datasource using a `k` value of 128. The query may return a different approximation on each execution.
+
+```sql
+SELECT APPROX_QUANTILE_DS("Distance", 0.5, 128)  AS "estimate_median"
+FROM "flight-carriers"
+```
+
+May return the following:
+
+| `estimate_median` |
+| -- | 
+| `569` |
+
+</details>
+
+[Learn more](sql-aggregations.md)
 
 ## APPROX_QUANTILE_FIXED_BUCKETS
 
-`APPROX_QUANTILE_FIXED_BUCKETS(expr, <NUMERIC>, <NUMERIC>, <NUMERIC>, <NUMERIC>, [<CHARACTER>])`
+Computes approximate quantiles on fixed buckets histogram column or a regular numeric column. Parameters are described in the [fixed buckets histogram](../development//extensions-core//approximate-histograms.md) documentation.
 
-**Function type:** [Aggregation](sql-aggregations.md)
+* **Syntax:** `APPROX_QUANTILE_FIXED_BUCKETS(expr, probability, numBuckets, lowerLimit, upperLimit, [outlierHandlingMode])`
+* **Function type:** Aggregation
 
-Computes approximate quantiles on fixed buckets histogram column or a regular numeric column.
+
+<details><summary>Example</summary>
+
+The following example approximates the median of a histogram on the `Distance` column from the `flight-carriers` datasource where the histogram has 10 buckets, a lower limit of zero, an upper limit of 2500, and outliers are ignored. 
+
+```sql
+SELECT APPROX_QUANTILE_FIXED_BUCKETS("Distance", 0.5, 10, 0, 2500, 'ignore')  AS "estimate_median"
+FROM "flight-carriers"
+```
+
+Returns the following:
+
+| `estimate_median` |
+| -- | 
+| `571.6983032226562` |
+
+</details>
+
+[Learn more](sql-aggregations.md)
 
 ## ARRAY[]
 
@@ -1027,36 +1068,108 @@ Returns the result of integer division of `x` by `y`.
 
 ## DS_CDF
 
-`DS_CDF(expr, splitPoint0, splitPoint1, ...)`
+Returns a string representing an approximation to the Cumulative Distribution Function given a list of split points that define the edges of the bins from a Quantiles sketch. The `expr` argument must return a Quantiles sketch.  
 
-**Function type:** [Scalar, sketch](sql-scalar.md#sketch-functions)
+* **Syntax:** `DS_CDF(expr, splitPoint0, splitPoint1, ...)`
+* **Function type:** Scalar, sketch
 
-Returns a string representing an approximation to the Cumulative Distribution Function given the specified bin definition.
+<details><summary>Example</summary>
+
+The following example specifies three split points to return cumulative distribution function approximations on the `Distance` column from the `flight-carriers` datasource. The query may return a different approximation for each bin on each execution.
+
+```sql 
+SELECT DS_CDF( DS_QUANTILES_SKETCH("Distance"), 750, 1500, 2250) AS "estimate_cdf"
+FROM "flight-carriers"
+```
+
+May return the following:
+
+| `estimate_cdf` | 
+| -- |
+| `[0.6332237016416492,0.8908411023460711,0.9612303007393957,1.0]` |
+
+</details>
+
+[Learn more](sql-scalar.md#sketch-functions)
 
 ## DS_GET_QUANTILE
 
-`DS_GET_QUANTILE(expr, fraction)`
+Returns the quantile estimate corresponding to `fraction` from a Quantiles sketch. The `fraction` argument must be a value between zero and one. The `expr` argument must return a Quantiles sketch.   
 
-**Function type:** [Scalar, sketch](sql-scalar.md#sketch-functions)
+* **Syntax:** `DS_GET_QUANTILE(expr, fraction)`
+* **Function type:** Scalar, sketch
 
-Returns the quantile estimate corresponding to `fraction` from a quantiles sketch.
+<details><summary>Example</summary>
+
+The following example approximates the median of the `Distance` column from the `flight-carriers` datasource. The query may return a different approximation with each execution.
+
+```sql
+SELECT DS_GET_QUANTILE( DS_QUANTILES_SKETCH("Distance"), 0.5) AS "estimate_median"
+FROM "flight-carriers"
+```
+
+May return the following:
+
+| `estimate_median` |
+| -- | 
+| `569` |
+
+</details>
+
+[Learn more](sql-scalar.md#sketch-functions)
 
 ## DS_GET_QUANTILES
 
-`DS_GET_QUANTILES(expr, fraction0, fraction1, ...)`
+Returns a string representing an array of quantile estimates corresponding to a list of fractions from a Quantiles sketch. Each fraction must be a value between zero and one. The `expr` argument must return a Quantiles sketch.   
 
-**Function type:** [Scalar, sketch](sql-scalar.md#sketch-functions)
+* **Syntax:** `DS_GET_QUANTILES(expr, fraction0, fraction1, ...)`
+* **Function type:** Scalar, sketch
 
-Returns a string representing an array of quantile estimates corresponding to a list of fractions from a quantiles sketch.
+<details><summary>Example</summary>
+
+The following example approximates the 25th, 50th, and 75th percentiles of the `Distance` column from the `flight-carriers` datasource. The query may return a different approximation for each percentile on each execution.
+
+```sql 
+SELECT DS_GET_QUANTILES( DS_QUANTILES_SKETCH("Distance"), 0.25, 0.5, 0.75) AS "estimate_fractions"
+FROM "flight-carriers"
+```
+
+May returns the following:
+
+| `estimate_fractions` |
+| -- | 
+| `[316.0,571.0,951.0]` |
+
+</details>
+
+[Learn more](sql-scalar.md#sketch-functions)
 
 ## DS_HISTOGRAM
 
-`DS_HISTOGRAM(expr, splitPoint0, splitPoint1, ...)`
+Returns a string representing an approximation to the histogram given a list of split points that define the histogram bins from a quantiles sketch. The `expr` argument must return a Quantiles sketch.    
 
-**Function type:** [Scalar, sketch](sql-scalar.md#sketch-functions)
+* **Syntax:** `DS_HISTOGRAM(expr, splitPoint0, splitPoint1, ...)`
+* **Function type:** Scalar, sketch
 
-Returns a string representing an approximation to the histogram given the specified bin definition.
+<details><summary>Example</summary>
 
+The following example specifies three split points to approximate a histogram on the `Distance` column from the `flight-carriers` datasource. The query may return a different approximation for each bin on each execution.
+
+```sql
+SELECT DS_HISTOGRAM( DS_QUANTILES_SKETCH("Distance"), 750, 1500, 2250) AS "estimate_histogram"
+FROM "flight-carriers"
+
+```
+
+May return the following:
+
+| `estimate_histogram` | 
+| -- |
+| `[354396.0,150199.00000000003,39848.000000000015,21694.99999999997]` |
+
+</details>
+
+[Learn more](sql-scalar.md#sketch-functions)
 
 ## DS_HLL
 
@@ -1068,27 +1181,110 @@ Creates an HLL sketch on a column containing HLL sketches or a regular column.
 
 ## DS_QUANTILE_SUMMARY
 
-`DS_QUANTILE_SUMMARY(expr)`
+Returns a string summary of a quantiles sketch. The `expr` argument must return a Quantiles sketch.
 
-**Function type:** [Scalar, sketch](sql-scalar.md#sketch-functions)
+* **Syntax:** `DS_QUANTILE_SUMMARY(expr)`
+* **Function type:** Scalar, sketch
 
-Returns a string summary of a quantiles sketch.
+<details><summary>Example</summary>
+
+The following example returns a summary of a Quantiles sketch on the `Distance` column from the `flight-carriers`.
+
+```sql
+SELECT DS_QUANTILE_SUMMARY( DS_QUANTILES_SKETCH("Distance") ) AS "summary"
+FROM "flight-carriers"
+```
+
+Returns the following:
+
+<table>
+<tr>
+<td><code>summary</code></td>
+</tr>
+<tr>
+<td>
+
+```
+### Quantiles DirectCompactDoublesSketch SUMMARY: 
+   Empty                        : false
+   Memory, Capacity bytes       : true, 6128
+   Estimation Mode              : true
+   K                            : 128
+   N                            : 566,138
+   Levels (Needed, Total, Valid): 12, 12, 5
+   Level Bit Pattern            : 100010100011
+   BaseBufferCount              : 122
+   Combined Buffer Capacity     : 762
+   Retained Items               : 762
+   Compact Storage Bytes        : 6,128
+   Updatable Storage Bytes      : 14,368
+   Normalized Rank Error        : 1.406%
+   Normalized Rank Error (PMF)  : 1.711%
+   Min Item                     : 2.400000e+01
+   Max Item                     : 4.962000e+03
+### END SKETCH SUMMARY
+```
+
+</td>
+</tr>
+</table>
+
+</details>
+
+[Learn more](sql-scalar.md#sketch-functions)
 
 ## DS_QUANTILES_SKETCH
 
-`DS_QUANTILES_SKETCH(expr, [k])`
+Creates a Quantiles sketch on a column containing Quantiles sketches or a regular column. The optional argument `k` determines the accuracy and size of the sketch. The [DataSketches Quantiles Sketch module](../development/extensions-core/datasketches-quantiles.md) provides more information on what values of `k` are accepted..
 
-**Function type:** [Aggregation](sql-aggregations.md)
+* **Syntax:** `DS_QUANTILES_SKETCH(expr, [k])`
+* **Function type:** Aggregation
 
-Creates a Quantiles sketch on a column containing Quantiles sketches or a regular column.
+<details><summary>Example</summary>
+
+The following example creates a Quantile sketch on the `Distance` column from the `flight-carriers` datasource.
+
+```sql
+SELECT DS_QUANTILES_SKETCH("Distance") AS "quantile_sketch"
+FROM "flight-carriers"
+```
+
+Returns the following:
+
+| `quantile_sketch` | 
+| -- | 
+| `AgMIGoAAAAB6owgAA...` |
+
+</details>
+
+[Learn more](sql-aggregations.md)
 
 ## DS_RANK
 
-`DS_RANK(expr, value)`
+Returns an approximate rank for `value` between zero and one, in which the rank signifies the fraction of the distribution less than the given value. The `expr` argument must return a Quantiles sketch.  
 
-**Function type:** [Scalar, sketch](sql-scalar.md#sketch-functions)
+* **Syntax:** `DS_RANK(expr, value)`
+* **Function type:** Scalar, sketch
 
-Returns an approximate rank between 0 and 1 of a given value, in which the rank signifies the fraction of the distribution less than the given value.
+<details><summary>Example</summary>
+
+The following example approximates what fraction of records have a lesser value than `500` in the `Distance` column from the `flight-carries` datasource. The query may return a different approximation on each execution.
+
+```sql
+SELECT DS_RANK( DS_QUANTILES_SKETCH("Distance"), 500) AS "estimate_rank"
+FROM "flight-carriers"
+```
+
+May return the following:
+
+| `estimate_rank` |
+| -- |
+| `0.43791089804959216` |
+
+
+</details>
+
+[Learn more](sql-scalar.md#sketch-functions)
 
 ## DS_THETA
 
@@ -1122,7 +1318,7 @@ Returns an intersection of Tuple sketches which each contain an array of double 
 
 **Function type:** [Scalar, sketch](sql-scalar.md#tuple-sketch-functions)
 
-Computes approximate sums of the values contained within a Tuple sketch which contains an array of double values as the Summary Object.
+Computes approximate sums of the values contained within a Tuple sketch which contains an array of double values as the Summary Object. 
 
 ## DS_TUPLE_DOUBLES_NOT
 

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -144,7 +144,7 @@ Deprecated in favor of [`APPROX_QUANTILE_DS`](#approx_quantile_ds).
 
 ## APPROX_QUANTILE_DS
 
-Computes approximate quantiles on a Quantiles sketch column or a regular numeric column. The `fraction` argument must be a value between zero and one. The optional argument `k` determines the accuracy and size of the sketch. The [DataSketches Quantiles Sketch module](../development/extensions-core/datasketches-quantiles.md) provides more information on what values of `k` are accepted..
+Computes approximate quantiles on a Quantiles sketch column or a regular numeric column. The parameter `k` determines the accuracy and size of the sketch. The [DataSketches Quantiles Sketch module](../development/extensions-core/datasketches-quantiles.md) provides more information on the parameter `k`.
 
 * **Syntax:** `APPROX_QUANTILE_DS(expr, fraction, [k])`
 * **Function type:** Aggregation
@@ -171,7 +171,7 @@ May return the following:
 
 ## APPROX_QUANTILE_FIXED_BUCKETS
 
-Computes approximate quantiles on fixed buckets histogram column or a regular numeric column. Parameters are described in the [fixed buckets histogram](../development//extensions-core//approximate-histograms.md) documentation.
+Computes approximate quantiles on fixed buckets histogram column or a regular numeric column. The [fixed buckets histogram](../development/extensions-core/approximate-histograms.md#fixed-buckets-histogram) documentation describes the parameters.
 
 * **Syntax:** `APPROX_QUANTILE_FIXED_BUCKETS(expr, probability, numBuckets, lowerLimit, upperLimit, [outlierHandlingMode])`
 * **Function type:** Aggregation
@@ -179,7 +179,7 @@ Computes approximate quantiles on fixed buckets histogram column or a regular nu
 
 <details><summary>Example</summary>
 
-The following example approximates the median of a histogram on the `Distance` column from the `flight-carriers` datasource where the histogram has 10 buckets, a lower limit of zero, an upper limit of 2500, and outliers are ignored. 
+The following example approximates the median of a histogram on the `Distance` column from the `flight-carriers` datasource. The histogram has 10 buckets, a lower limit of zero, an upper limit of 2500, and outliers are ignored. 
 
 ```sql
 SELECT APPROX_QUANTILE_FIXED_BUCKETS("Distance", 0.5, 10, 0, 2500, 'ignore')  AS "estimate_median"
@@ -1068,7 +1068,7 @@ Returns the result of integer division of `x` by `y`.
 
 ## DS_CDF
 
-Returns a string representing an approximation to the Cumulative Distribution Function given a list of split points that define the edges of the bins from a Quantiles sketch. The `expr` argument must return a Quantiles sketch.  
+Returns a string representing an approximation to the cumulative distribution function given a list of split points that define the edges of the bins from a Quantiles sketch.  
 
 * **Syntax:** `DS_CDF(expr, splitPoint0, splitPoint1, ...)`
 * **Function type:** Scalar, sketch
@@ -1094,7 +1094,7 @@ May return the following:
 
 ## DS_GET_QUANTILE
 
-Returns the quantile estimate corresponding to `fraction` from a Quantiles sketch. The `fraction` argument must be a value between zero and one. The `expr` argument must return a Quantiles sketch.   
+Returns the quantile estimate corresponding to `fraction` from a Quantiles sketch. 
 
 * **Syntax:** `DS_GET_QUANTILE(expr, fraction)`
 * **Function type:** Scalar, sketch
@@ -1120,7 +1120,7 @@ May return the following:
 
 ## DS_GET_QUANTILES
 
-Returns a string representing an array of quantile estimates corresponding to a list of fractions from a Quantiles sketch. Each fraction must be a value between zero and one. The `expr` argument must return a Quantiles sketch.   
+Returns a string representing an array of quantile estimates corresponding to a list of fractions from a Quantiles sketch. 
 
 * **Syntax:** `DS_GET_QUANTILES(expr, fraction0, fraction1, ...)`
 * **Function type:** Scalar, sketch
@@ -1146,7 +1146,7 @@ May returns the following:
 
 ## DS_HISTOGRAM
 
-Returns a string representing an approximation to the histogram given a list of split points that define the histogram bins from a quantiles sketch. The `expr` argument must return a Quantiles sketch.    
+Returns a string representing an approximation to the histogram given a list of split points that define the histogram bins from a Quantiles sketch. 
 
 * **Syntax:** `DS_HISTOGRAM(expr, splitPoint0, splitPoint1, ...)`
 * **Function type:** Scalar, sketch
@@ -1181,8 +1181,7 @@ Creates an HLL sketch on a column containing HLL sketches or a regular column.
 
 ## DS_QUANTILE_SUMMARY
 
-Returns a string summary of a quantiles sketch. The `expr` argument must return a Quantiles sketch.
-
+Returns a string summary of a Quantiles sketch. 
 * **Syntax:** `DS_QUANTILE_SUMMARY(expr)`
 * **Function type:** Scalar, sketch
 
@@ -1235,7 +1234,7 @@ Returns the following:
 
 ## DS_QUANTILES_SKETCH
 
-Creates a Quantiles sketch on a column containing Quantiles sketches or a regular column. The optional argument `k` determines the accuracy and size of the sketch. The [DataSketches Quantiles Sketch module](../development/extensions-core/datasketches-quantiles.md) provides more information on what values of `k` are accepted..
+Creates a Quantiles sketch on a column containing Quantiles sketches or a regular column. The parameter `k` determines the accuracy and size of the sketch. The [DataSketches Quantiles Sketch module](../development/extensions-core/datasketches-quantiles.md) provides more information on the parameter `k`.
 
 * **Syntax:** `DS_QUANTILES_SKETCH(expr, [k])`
 * **Function type:** Aggregation
@@ -1261,7 +1260,7 @@ Returns the following:
 
 ## DS_RANK
 
-Returns an approximate rank for `value` between zero and one, in which the rank signifies the fraction of the distribution less than the given value. The `expr` argument must return a Quantiles sketch.  
+Returns an approximate rank for `value` between zero and one, in which the rank signifies the fraction of the distribution less than `value`.
 
 * **Syntax:** `DS_RANK(expr, value)`
 * **Function type:** Scalar, sketch


### PR DESCRIPTION
### Description

The PR adds examples for functions `DS_GET_QUANTILE`, `DS_GET_QUANTILES`, `DS_HISTOGRAM`, `DS_CDF`, `DS_RANK`, `APPROX_QUANTILE`, `APPROX_QUANTILE_DS`, `APPROX_QUANTILE_FIXED_BUCKETS` , `DS_QUANTILES_SKETCH`, and `DS_QUANTILE_SUMMARY`.

This PR has:

- [X] been self-reviewed.
- [X] Link-linter passed
- [X] Spellchecker passed